### PR TITLE
refactor: removed forEach util from most of the places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .idea
+.vscode
 .tscache
 .DS_Store
 node_modules/

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -112,13 +112,13 @@ module.exports = function xhrAdapter(config) {
 
     // Add headers to the request
     if ('setRequestHeader' in request) {
-      utils.forEach(requestHeaders, function setRequestHeader(val, key) {
+      Object.keys(requestHeaders).forEach(function setRequestHeader(key) {
         if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') {
           // Remove Content-Type if data is undefined
           delete requestHeaders[key];
         } else {
           // Otherwise add header to the request
-          request.setRequestHeader(key, val);
+          request.setRequestHeader(key, requestHeaders[key]);
         }
       });
     }

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -62,7 +62,7 @@ Axios.prototype.getUri = function getUri(config) {
 };
 
 // Provide aliases for supported request methods
-utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData(method) {
+['delete', 'get', 'head', 'options'].forEach(function forEachMethodNoData(method) {
   /*eslint func-names:0*/
   Axios.prototype[method] = function(url, config) {
     return this.request(utils.merge(config || {}, {
@@ -72,7 +72,7 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
   };
 });
 
-utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
+['post', 'put', 'patch'].forEach(function forEachMethodWithData(method) {
   /*eslint func-names:0*/
   Axios.prototype[method] = function(url, data, config) {
     return this.request(utils.merge(config || {}, {

--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var utils = require('./../utils');
-
 function InterceptorManager() {
   this.handlers = [];
 }
@@ -42,7 +40,7 @@ InterceptorManager.prototype.eject = function eject(id) {
  * @param {Function} fn The function to call for each interceptor
  */
 InterceptorManager.prototype.forEach = function forEach(fn) {
-  utils.forEach(this.handlers, function forEachHandler(h) {
+  this.handlers.forEach(function forEachHandler(h) {
     if (h !== null) {
       fn(h);
     }

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -47,8 +47,7 @@ module.exports = function dispatchRequest(config) {
     config.headers || {}
   );
 
-  utils.forEach(
-    ['delete', 'get', 'head', 'post', 'put', 'patch', 'common'],
+  ['delete', 'get', 'head', 'post', 'put', 'patch', 'common'].forEach(
     function cleanHeaderConfig(method) {
       delete config.headers[method];
     }

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -15,13 +15,13 @@ module.exports = function mergeConfig(config1, config2) {
   config2 = config2 || {};
   var config = {};
 
-  utils.forEach(['url', 'method', 'params', 'data'], function valueFromConfig2(prop) {
+  ['url', 'method', 'params', 'data'].forEach(function valueFromConfig2(prop) {
     if (typeof config2[prop] !== 'undefined') {
       config[prop] = config2[prop];
     }
   });
 
-  utils.forEach(['headers', 'auth', 'proxy'], function mergeDeepProperties(prop) {
+  ['headers', 'auth', 'proxy'].forEach(function mergeDeepProperties(prop) {
     if (utils.isObject(config2[prop])) {
       config[prop] = utils.deepMerge(config1[prop], config2[prop]);
     } else if (typeof config2[prop] !== 'undefined') {
@@ -33,13 +33,28 @@ module.exports = function mergeConfig(config1, config2) {
     }
   });
 
-  utils.forEach([
-    'baseURL', 'url', 'transformRequest', 'transformResponse', 'paramsSerializer',
-    'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
-    'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'maxContentLength',
-    'validateStatus', 'maxRedirects', 'httpAgent', 'httpsAgent', 'cancelToken',
+  [
+    'baseURL',
+    'url',
+    'transformRequest',
+    'transformResponse',
+    'paramsSerializer',
+    'timeout',
+    'withCredentials',
+    'adapter',
+    'responseType',
+    'xsrfCookieName',
+    'xsrfHeaderName',
+    'onUploadProgress',
+    'onDownloadProgress',
+    'maxContentLength',
+    'validateStatus',
+    'maxRedirects',
+    'httpAgent',
+    'httpsAgent',
+    'cancelToken',
     'socketPath'
-  ], function defaultToConfig2(prop) {
+  ].forEach(function defaultToConfig2(prop) {
     if (typeof config2[prop] !== 'undefined') {
       config[prop] = config2[prop];
     } else if (typeof config1[prop] !== 'undefined') {

--- a/lib/core/transformData.js
+++ b/lib/core/transformData.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var utils = require('./../utils');
-
 /**
  * Transform the data for a request or a response
  *
@@ -11,8 +9,9 @@ var utils = require('./../utils');
  * @returns {*} The resulting transformed data
  */
 module.exports = function transformData(data, headers, fns) {
+  fns = Array.isArray(fns) ? fns : [fns];
   /*eslint no-param-reassign:0*/
-  utils.forEach(fns, function transform(fn) {
+  fns.filter(Boolean).forEach(function transform(fn) {
     data = fn(data, headers);
   });
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -87,11 +87,11 @@ defaults.headers = {
   }
 };
 
-utils.forEach(['delete', 'get', 'head'], function forEachMethodNoData(method) {
+['delete', 'get', 'head'].forEach(function forEachMethodNoData(method) {
   defaults.headers[method] = {};
 });
 
-utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
+['post', 'put', 'patch'].forEach(function forEachMethodWithData(method) {
   defaults.headers[method] = utils.merge(DEFAULT_CONTENT_TYPE);
 });
 

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -34,18 +34,20 @@ module.exports = function buildURL(url, params, paramsSerializer) {
   } else {
     var parts = [];
 
-    utils.forEach(params, function serialize(val, key) {
+    Object.keys(params).forEach(function serialize(key) {
+      var val = params[key];
+
       if (val === null || typeof val === 'undefined') {
         return;
       }
 
-      if (utils.isArray(val)) {
+      if (Array.isArray(val)) {
         key = key + '[]';
       } else {
         val = [val];
       }
 
-      utils.forEach(val, function parseValue(v) {
+      val.forEach(function parseValue(v) {
         if (utils.isDate(v)) {
           v = v.toISOString();
         } else if (utils.isObject(v)) {

--- a/lib/helpers/normalizeHeaderName.js
+++ b/lib/helpers/normalizeHeaderName.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var utils = require('../utils');
-
 module.exports = function normalizeHeaderName(headers, normalizedName) {
-  utils.forEach(headers, function processHeader(value, name) {
+  if (!headers) {
+    return;
+  }
+  Object.keys(headers).forEach(function processHeader(name) {
     if (name !== normalizedName && name.toUpperCase() === normalizedName.toUpperCase()) {
-      headers[normalizedName] = value;
+      headers[normalizedName] = headers[name];
       delete headers[name];
     }
   });

--- a/lib/helpers/parseHeaders.js
+++ b/lib/helpers/parseHeaders.js
@@ -32,7 +32,7 @@ module.exports = function parseHeaders(headers) {
 
   if (!headers) { return parsed; }
 
-  utils.forEach(headers.split('\n'), function parser(line) {
+  headers.split('\n').forEach(function parser(line) {
     i = line.indexOf(':');
     key = utils.trim(line.substr(0, i)).toLowerCase();
     val = utils.trim(line.substr(i + 1));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -295,7 +295,8 @@ function deepMerge(/* obj1, obj2, obj3, ... */) {
  * @return {Object} The resulting value of object a
  */
 function extend(a, b, thisArg) {
-  forEach(b, function assignValue(val, key) {
+  Object.keys(b).forEach(function assignValue(key) {
+    var val = b[key];
     if (thisArg && typeof val === 'function') {
       a[key] = bind(val, thisArg);
     } else {


### PR DESCRIPTION
There is a couple of functions in utils still using it, but the rest was replaced with simpler native alternative. It's only being used in `merge`, `deepMerge` and `extend` utils which are probably will be replaced with polyfills soon.